### PR TITLE
Fix: Correct dbConfig typo in dbService

### DIFF
--- a/src/services/dbService.js
+++ b/src/services/dbService.js
@@ -39,7 +39,7 @@ if (config.db.sslMode && ['require', 'prefer', 'allow', 'verify-ca', 'verify-ful
 
 let pool;
 try {
-  pool = new Pool(dbConfig);
+  pool = new Pool(dbServiceConfig);
 
   pool.on('connect', () => {
     logger.info('PostgreSQL connected successfully.');


### PR DESCRIPTION
Changed `dbConfig` to `dbServiceConfig` in `src/services/dbService.js` to resolve a ReferenceError that prevented the PostgreSQL pool from being created.