### PR TITLE
Debug: Add diagnostic logging for product ID in getProductStock

### DIFF
--- a/src/services/dolibarrApiService.js
+++ b/src/services/dolibarrApiService.js
@@ -218,5 +218,6 @@ async function getProductStock(dolibarrProductId, queryParams = {}) {
   // 3. Stock info might be part of the /products/{dolibarrProductId} response itself.
   // This example assumes a dedicated sub-resource or filterable endpoint.
   // Changed from /stocklevels to /stock based on Swagger spec and 404 errors
+  logger.info({ dolibarrProductId, type: typeof dolibarrProductId }, 'getProductStock called with ID:'); // Diagnostic log
   return request(`/products/${dolibarrProductId}/stock`, {}, queryParams);
 }


### PR DESCRIPTION
I added a logger statement in the getProductStock function within dolibarrApiService.js to output the dolibarrProductId and its type. This is to help diagnose why API calls for product stock might be failing from the middleware when direct curl tests succeed.