### PR TITLE
I've added a logger statement in `syncStockLevels` within `syncServic…

### DIFF
--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -293,8 +293,15 @@ async function syncStockLevels() {
   for (const dlbProdId of uniqProdIds) {
     try {
       const stockApiData = await dolibarrApi.getProductStock(dlbProdId);
+      // Log the raw API response for this product ID
+      logger.info({ dlbProdId, stockApiDataFromDolibarr: stockApiData }, 'Raw stock API data received:');
+
       const entries = Array.isArray(stockApiData) ? stockApiData : (stockApiData ? [stockApiData] : []);
-      if (entries.length === 0) continue;
+      if (entries.length === 0) {
+        // Also log if entries array is empty after processing stockApiData
+        logger.info({ dlbProdId, processedEntries: entries }, 'No processable stock entries found after parsing API data.');
+        continue;
+      }
       for (const entry of entries) {
         let locProdId = null; let locVarId = null;
         if (entry.fk_product_fils || entry.variant_id) {


### PR DESCRIPTION
…e.js`

to output the `dlbProdId` and the raw `stockApiData` received from Dolibarr. This will help you inspect the API response structure for products where the stock API call does not result in a 404 error, particularly for product ID 1, so you can understand how the data is being returned and why it might not be processed into the `stock_levels` table correctly.