### PR TITLE
Fix: Correct import of handleWebhook in webhookRoutes

### DIFF
--- a/src/routes/webhookRoutes.js
+++ b/src/routes/webhookRoutes.js
@@ -1,5 +1,6 @@
 // src/routes/webhookRoutes.js
-import { handleWebhook } from '../services/syncService.js';
+import syncService from '../services/syncService.js';
+const { handleWebhook } = syncService;
 import config from '../config/index.js'; // Corrected import
 
 async function webhookRoutes(fastify, options) {


### PR DESCRIPTION
I changed the import in `src/routes/webhookRoutes.js` from a named import to a default import for `syncService` and then destructured the `handleWebhook` function. This resolves the SyntaxError caused by `syncService.js` exporting `handleWebhook` as part of its default export object.