### PR TITLE
Docs: Enhance Swagger API documentation

### DIFF
--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -4,6 +4,9 @@ import productController from '../controllers/productController.js';
 // Define schema/validation for request/response if desired, using Fastify's schema capabilities.
 // Example for listProducts query parameters:
 const listProductsSchema = {
+  summary: 'List products',
+  description: 'Retrieves a paginated list of synchronized products. Supports filtering by category_id and sorting by various fields.',
+  tags: ['Products'],
   querystring: {
     type: 'object',
     properties: {
@@ -29,6 +32,9 @@ const listProductsSchema = {
 
 // Example for getProductBySlug params
 const getProductBySlugSchema = {
+  summary: 'Get product by slug',
+  description: 'Retrieves detailed information for a single product by its URL slug, including its variants, image URLs, stock levels, and associated categories.',
+  tags: ['Products'],
   params: {
     type: 'object',
     properties: {
@@ -42,7 +48,15 @@ const getProductBySlugSchema = {
 
 async function apiRoutes(fastify, options) {
   // Category Routes
-  fastify.get('/categories', categoryController.getAllCategories);
+  fastify.get('/categories', {
+    schema: {
+      summary: 'List all categories',
+      description: 'Retrieves a list of all synchronized categories from the local database.',
+      tags: ['Categories'],
+      // TODO: Define a response schema for categories if not already implicitly handled by controller
+      // response: { 200: { type: 'array', items: { type: 'object', properties: { id: {type: 'integer'}, name: {type: 'string'}, ... } } } }
+    }
+  }, categoryController.getAllCategories);
   // fastify.get('/categories/:idOrSlug', categoryController.getCategory); // Example for single category
 
   // Product Routes

--- a/src/routes/webhookRoutes.js
+++ b/src/routes/webhookRoutes.js
@@ -3,8 +3,74 @@ import syncService from '../services/syncService.js';
 const { handleWebhook } = syncService;
 import config from '../config/index.js'; // Corrected import
 
+const webhookPayloadSchema = {
+  type: 'object',
+  required: ['triggercode', 'object'],
+  properties: {
+    triggercode: {
+      type: 'string',
+      description: 'The event code from Dolibarr (e.g., PRODUCT_CREATE, CATEGORY_MODIFY).',
+      examples: ['PRODUCT_CREATE', 'STOCK_MOVEMENT'],
+    },
+    object: {
+      type: 'object',
+      description: 'The Dolibarr object data associated with the event.',
+      properties: {
+        id: { type: ['integer', 'string'], description: 'ID of the Dolibarr object.' },
+        // Add other common fields if known, or allow additionalProperties
+      },
+      additionalProperties: true,
+    },
+    // Potentially other fields Dolibarr might send
+  },
+};
+
+const webhookResponseSchema = {
+  200: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'Webhook received and processing initiated.' },
+    },
+  },
+  400: {
+    type: 'object',
+    properties: {
+      error: { type: 'string' },
+      message: { type: 'string' },
+      details: { type: 'array', items: { type: 'object' } } // Optional for validation errors
+    }
+  },
+  401: {
+    type: 'object',
+    properties: {
+      error: { type: 'string', example: 'Unauthorized' },
+    }
+  },
+  500: {
+    type: 'object',
+    properties: {
+      error: { type: 'string', example: 'Internal Server Error during webhook reception.' },
+    }
+  }
+};
+
 async function webhookRoutes(fastify, options) {
-  fastify.post('/webhook', async (request, reply) => {
+  const routeSchema = {
+    description: 'Receives and processes webhooks from a Dolibarr ERP instance. This endpoint listens for various events (e.g., product creation, stock updates) and triggers corresponding actions within the middleware, such as data synchronization. A shared secret can be configured for security.',
+    summary: 'Dolibarr Webhook Receiver',
+    tags: ['Webhooks'],
+    body: webhookPayloadSchema,
+    response: webhookResponseSchema,
+    // It might also be useful to document expected headers like X-Dolibarr-Webhook-Secret
+    // headers: {
+    //   type: 'object',
+    //   properties: {
+    //     'X-Dolibarr-Webhook-Secret': { type: 'string', description: 'Shared secret for webhook authentication (if configured).' }
+    //   }
+    // }
+  };
+
+  fastify.post('/webhook', { schema: routeSchema }, async (request, reply) => {
     const { body: payload, headers } = request;
     // Use request.log provided by Fastify, which is configured in server.js
     const logger = request.log;

--- a/src/server.js
+++ b/src/server.js
@@ -29,7 +29,23 @@ await fastify.register(fastifyHelmet, {
 
 
 // Declare a route for health check
-fastify.get('/health', async (request, reply) => {
+const healthCheckSchema = {
+  summary: 'Health Check',
+  description: 'Provides the operational status of the middleware. Indicates if the service is running and the current server timestamp.',
+  tags: ['Monitoring'],
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'ok' },
+        timestamp: { type: 'string', format: 'date-time' },
+        // dbStatus: { type: 'string', example: 'connected' } // Example if db check is added
+      },
+    },
+  },
+};
+
+fastify.get('/health', { schema: healthCheckSchema }, async (request, reply) => {
   // Optionally, include database connection status in health check later
   // const dbOk = await dbService.testConnection();
   return {


### PR DESCRIPTION
I've added detailed Swagger/OpenAPI schemas, summaries, descriptions, and tags to various routes:

- `POST /webhooks/webhook`: I defined the request body and response schemas, and added a summary and description.
- `GET /api/v1/categories`: I added a summary and description.
- `GET /api/v1/products`: I added a summary and description.
- `GET /api/v1/products/:slug`: I added a summary and description.
- `GET /health`: I added a summary, description, and response schema.

These changes improve the clarity and usability of the auto-generated API documentation available at the /documentation endpoint.