### PR TITLE
Fix: Update @fastify/swagger-ui for Fastify 5.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dotenv": "^17.1.0",
     "fastify": "^5.4.0",
     "@fastify/swagger": "^9.5.1",
-    "@fastify/swagger-ui": "^3.0.0",
+    "@fastify/swagger-ui": "^4.0.0",
     "@fastify/helmet": "^13.0.1",
     "node-cron": "^3.0.3",
     "pg": "^8.16.3",


### PR DESCRIPTION
I changed the version of `@fastify/swagger-ui` in `package.json` from `^3.0.0` to `^4.0.0`. This resolves the `FST_ERR_PLUGIN_VERSION_MISMATCH` error encountered during deployment on Render, as `@fastify/swagger-ui` v3.x expects Fastify v4.x, while your project uses Fastify v5.4.0. Version 4.x of `@fastify/swagger-ui` is compatible with Fastify 5.x.