### PR TITLE
Fix: Align Node.js version and package dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build - Install dependencies
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /usr/src/app
 
@@ -11,7 +11,7 @@ COPY package*.json ./
 RUN npm install --omit=dev --legacy-peer-deps
 
 # Stage 2: Production - Copy built assets and run the app
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This commit addresses the persistent deployment error by:

1.  Updating the `Dockerfile` to use `node:20-alpine`. This resolves the `EBADENGINE` warnings by aligning the runtime environment with the requirements of newer dependencies (which expect Node.js >= 20).

2.  Ensuring `package.json` has the correct version for `@fastify/swagger-ui` (`^4.0.0`), which is compatible with Fastify v5.x.

This comprehensive fix aligns the entire environment (Node.js version and package versions) and should resolve the version mismatch errors during deployment on Render.