### PR TITLE
fix: Parse stringified JSON payload from Dolibarr

### DIFF
--- a/src/routes/webhookRoutes.js
+++ b/src/routes/webhookRoutes.js
@@ -5,9 +5,22 @@ import config from '../config/index.js';
 
 async function webhookRoutes(fastify, options) {
   fastify.post('/webhook', async (request, reply) => {
-    const { body: payload, headers } = request;
+    let { body: payload, headers } = request;
     // Use request.log provided by Fastify, which is configured in server.js
     const logger = request.log;
+
+    // Handle stringified JSON payload from Dolibarr
+    if (typeof payload === 'object' && payload !== null) {
+      const keys = Object.keys(payload);
+      if (keys.length === 1 && keys[0].startsWith('{') && keys[0].endsWith('}')) {
+        try {
+          payload = JSON.parse(keys[0]);
+        } catch (e) {
+          logger.error({ err: e, payload: keys[0] }, 'Error parsing stringified JSON payload.');
+          return reply.status(400).send({ error: 'Invalid JSON format in payload.' });
+        }
+      }
+    }
 
     logger.info({ payload }, 'Received webhook payload.');
 


### PR DESCRIPTION
This change updates the webhook handler to correctly parse the stringified JSON payload sent by Dolibarr when the content type is `application/x-www-form-urlencoded`.