### PR TITLE
fix: Use Supabase Transaction Pooler for database connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ PORT=3000
 LOG_LEVEL=info # e.g., trace, debug, info, warn, error, fatal
 
 # Database Settings
-DB_HOST=db.zkpklorrmzjfgagvvvea.supabase.co
-DB_PORT=5432
-DB_USER=postgres
+DB_HOST=aws-0-eu-west-3.pooler.supabase.com
+DB_PORT=6543
+DB_USER=postgres.zkpklorrmzjfgagvvvea
 DB_PASSWORD=your_supabase_password # Replace with your actual password
 DB_NAME=postgres
 DB_SSL_MODE=require

--- a/src/services/dbService.js
+++ b/src/services/dbService.js
@@ -10,7 +10,6 @@ const dbServiceConfig = {
   database: config.db.database,
   password: config.db.password,
   port: config.db.port,
-  family: 4,
 };
 
 // SSL configuration based on centralized config


### PR DESCRIPTION
This change updates the database connection to use the Supabase Transaction Pooler, which is compatible with IPv4 networks like Render. The `.env.example` file has been updated with the new connection details, and the `family: 4` setting has been removed from the database configuration as it is no longer needed.