### PR TITLE
fix: Force IPv4 for database connection

### DIFF
--- a/src/services/dbService.js
+++ b/src/services/dbService.js
@@ -5,13 +5,14 @@ import logger from '../utils/logger.js'; // Import shared logger
 const { Pool } = pg;
 
 const dbServiceConfig = config.db.connectionString
-  ? { connectionString: config.db.connectionString }
+  ? { connectionString: config.db.connectionString, family: 4 }
   : {
       user: config.db.user,
       host: config.db.host,
       database: config.db.database,
       password: config.db.password,
       port: config.db.port,
+      family: 4,
     };
 
 // SSL configuration based on centralized config


### PR DESCRIPTION
This change forces the database connection to use IPv4 by adding the `family: 4` option to the database configuration. This should resolve the `ENETUNREACH` error when connecting to the Supabase database from Render.