### PR TITLE
fix: Remove IPv4 constraint for database connection

### DIFF
--- a/src/services/dbService.js
+++ b/src/services/dbService.js
@@ -5,14 +5,13 @@ import logger from '../utils/logger.js'; // Import shared logger
 const { Pool } = pg;
 
 const dbServiceConfig = config.db.connectionString
-  ? { connectionString: config.db.connectionString, family: 4 }
+  ? { connectionString: config.db.connectionString }
   : {
       user: config.db.user,
       host: config.db.host,
       database: config.db.database,
       password: config.db.password,
       port: config.db.port,
-      family: 4,
     };
 
 // SSL configuration based on centralized config


### PR DESCRIPTION
This change removes the `family: 4` option from the PostgreSQL connection configuration. This was causing database connection failures on Render due to IPv6 resolution issues. Removing the constraint allows the application to connect to the database using either IPv4 or IPv6, which should resolve the `ENETUNREACH` error when deployed on Render.