### PR TITLE
fix: Enhance webhook validation and add tests

### DIFF
--- a/src/routes/webhookRoutes.js
+++ b/src/routes/webhookRoutes.js
@@ -12,8 +12,19 @@ async function webhookRoutes(fastify, options) {
     const { secret } = params;
     const expectedSecret = config.dolibarrWebhookSecret;
 
-    if (!expectedSecret || secret !== expectedSecret) {
-      logger.warn({ providedSecret: secret }, 'Unauthorized webhook attempt: Invalid or missing secret in URL.');
+    // Enhanced logging for debugging
+    logger.info({
+        receivedSecret: secret,
+        expectedSecret: expectedSecret,
+        receivedLength: secret ? secret.length : 0,
+        expectedLength: expectedSecret ? expectedSecret.length : 0,
+    }, 'Comparing webhook secrets.');
+
+    if (!expectedSecret || !secret || secret.trim() !== expectedSecret.trim()) {
+      logger.warn({
+          providedSecret: secret,
+          match: false,
+      }, 'Unauthorized webhook attempt: Invalid or missing secret in URL.');
       return reply.status(401).send({ error: 'Unauthorized' });
     }
 

--- a/src/routes/webhookRoutes.test.js
+++ b/src/routes/webhookRoutes.test.js
@@ -1,0 +1,75 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import webhookRoutes from './webhookRoutes.js';
+// config is now mocked
+import syncService from '../services/syncService.js';
+
+const testSecret = 'test-secret-123';
+
+// Mock the config module before other imports that might use it
+vi.mock('../config/index.js', () => ({
+  default: {
+    dolibarrWebhookSecret: 'test-secret-123', // Use literal value to avoid hoisting issues
+  },
+}));
+
+// Mock the syncService to prevent actual processing
+vi.mock('../services/syncService.js', () => ({
+  default: {
+    handleWebhook: vi.fn().mockResolvedValue(),
+  },
+}));
+
+describe('Webhook Security', () => {
+  let app;
+
+  beforeEach(async () => {
+    app = Fastify();
+    await app.register(webhookRoutes, { prefix: '/webhooks' });
+    await app.ready();
+  });
+
+  test('should return 401 if secret is incorrect', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/webhook/wrong-secret',
+      payload: { triggercode: 'TEST', object: {} },
+    });
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.payload).error).toBe('Unauthorized');
+  });
+
+  test('should return 401 if secret is missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/webhook/',
+      payload: { triggercode: 'TEST', object: {} },
+    });
+    // Our logic correctly identifies the missing secret and returns 401
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('should return 200 and process webhook if secret is correct', async () => {
+    const payload = { triggercode: 'PRODUCT_CREATE', object: { id: 1 } };
+    const response = await app.inject({
+      method: 'POST',
+      url: `/webhooks/webhook/${testSecret}`,
+      payload: payload,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload).message).toBe('Webhook received and processing initiated.');
+    // Check if handleWebhook was called
+    expect(syncService.handleWebhook).toHaveBeenCalledWith(payload, expect.anything());
+  });
+
+  test('should handle secrets with trailing spaces', async () => {
+    const payload = { triggercode: 'PRODUCT_CREATE', object: { id: 1 } };
+    // Simulate a secret with a trailing space from the URL
+    const response = await app.inject({
+      method: 'POST',
+      url: `/webhooks/webhook/${testSecret}  `,
+      payload: payload,
+    });
+    expect(response.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
This commit addresses the persistent `401 Unauthorized` issue with webhooks by:

1.  Adding detailed diagnostic logging to the webhook handler to output the received and expected secrets, along with their lengths. This will help diagnose mismatches in the production environment.
2.  Making the secret comparison more robust by using `trim()` to remove any leading or trailing whitespace from both the received and expected secrets.
3.  Introducing a `vitest` unit test suite for the webhook route to programmatically verify the security logic. The tests confirm that valid secrets are accepted, and invalid or missing secrets are correctly rejected.

These changes provide a more robust and debuggable webhook security implementation.