### PR TITLE
fix: Correct path to webhook secret in config

### DIFF
--- a/src/routes/webhookRoutes.js
+++ b/src/routes/webhookRoutes.js
@@ -10,7 +10,7 @@ async function webhookRoutes(fastify, options) {
 
     // Security Check: Validate webhook secret from URL parameter
     const { secret } = params;
-    const expectedSecret = config.dolibarrWebhookSecret;
+    const expectedSecret = config.dolibarr.webhookSecret;
 
     // Enhanced logging for debugging
     logger.info({

--- a/src/routes/webhookRoutes.test.js
+++ b/src/routes/webhookRoutes.test.js
@@ -9,7 +9,9 @@ const testSecret = 'test-secret-123';
 // Mock the config module before other imports that might use it
 vi.mock('../config/index.js', () => ({
   default: {
-    dolibarrWebhookSecret: 'test-secret-123', // Use literal value to avoid hoisting issues
+    dolibarr: {
+      webhookSecret: 'test-secret-123', // Use literal value to avoid hoisting issues
+    },
   },
 }));
 


### PR DESCRIPTION
This commit fixes a bug where the webhook handler was looking for `config.dolibarrWebhookSecret` instead of the correct, nested path `config.dolibarr.webhookSecret`.

This caused the application to always read the expected secret as `undefined`, leading to persistent `401 Unauthorized` errors even when the environment variable was set correctly.

The corresponding unit test mock for the config has also been updated to reflect the correct nested structure, and all tests are passing.