### PR TITLE
feat: Automate initial sync on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,15 @@ Follow these instructions to set up and run the project in your local developmen
 
 ### Initial Data Synchronization
 
-After the application is running, you need to perform an initial data synchronization to populate the local database with data from your Dolibarr instance.
+The initial data synchronization is now automated and will run when the application starts if the `RUN_INITIAL_SYNC` environment variable is set to `true`.
 
-To run the initial sync, execute the following command in a separate terminal:
+To enable the initial sync, add the following line to your `.env` file:
 
-```bash
-docker-compose exec app npm run sync:initial
+```env
+RUN_INITIAL_SYNC=true
 ```
+
+When you deploy the application with this environment variable set to `true`, it will automatically perform a full synchronization of all data from Dolibarr. Once the initial sync is complete, you can set this variable to `false` or remove it to prevent the sync from running on every application restart.
 
 ### API Documentation
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -62,6 +62,7 @@ const config = {
     stockSyncInterval: process.env.POLLING_STOCK_SYNC_INTERVAL || '0 */1 * * *', // Default: every hour for stock
     // productSyncInterval: process.env.POLLING_PRODUCT_SYNC_INTERVAL || '0 2 * * *', // Default: daily at 2 AM for full product sync
   },
+  runInitialSync: process.env.RUN_INITIAL_SYNC === 'true' || false,
   // Add other configurations as needed
   // e.g., webhookSecret: process.env.DOLIBARR_WEBHOOK_SECRET already added
 };

--- a/src/server.js
+++ b/src/server.js
@@ -180,6 +180,13 @@ const start = async () => {
       pollingService.start();
     }
 
+    // Run initial sync if enabled
+    if (config.runInitialSync) {
+      syncService.runInitialSync().catch(err => {
+        fastify.log.error(err, 'Initial sync failed');
+      });
+    }
+
   } catch (err) {
     fastify.log.error(err);
     process.exit(1);


### PR DESCRIPTION
This commit automates the initial data synchronization on application startup. A new `RUN_INITIAL_SYNC` environment variable has been added to control this behavior. When this variable is set to `true`, the application will perform a full sync from Dolibarr to the local database.

The `README.md` file has been updated to document this new feature.